### PR TITLE
fix: removed credential workaround

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <aws.java.sdk.version>2.31.59</aws.java.sdk.version>
+        <aws.java.sdk.version>2.31.63</aws.java.sdk.version>
         <aws.schema.registry.version>1.1.15</aws.schema.registry.version>
         <ch.qos.logback.version>1.5.18</ch.qos.logback.version>
         <com.fasterxml.jackson.version>2.19.0</com.fasterxml.jackson.version>

--- a/src/main/java/software/amazon/event/kafkaconnector/auth/EventBridgeAwsCredentialsProviderFactory.java
+++ b/src/main/java/software/amazon/event/kafkaconnector/auth/EventBridgeAwsCredentialsProviderFactory.java
@@ -83,25 +83,13 @@ public abstract class EventBridgeAwsCredentialsProviderFactory {
     return getStsAssumeRoleCredentialsProvider(config);
   }
 
-  // Temporary workaround until AWS SDK issue is fixed:
-  // https://github.com/aws/aws-sdk-java-v2/issues/5635
-  private static ProfileFileSupplier wrappedProfileDefaultSupplier() {
-    return () -> {
-      try {
-        return ProfileFileSupplier.defaultSupplier().get();
-      } catch (NullPointerException e) {
-        return ProfileFile.defaultProfileFile();
-      }
-    };
-  }
-
   private static DefaultCredentialsProvider getDefaultCredentialsProvider(
       EventBridgeSinkConfig config) {
     var builder = DefaultCredentialsProvider.builder();
 
     // Leverage DefaultSupplier to automatically reload credentials on file refresh
     // https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials-profiles.html#profile-reloading
-    builder.profileFile(wrappedProfileDefaultSupplier());
+    builder.profileFile(ProfileFileSupplier.defaultSupplier());
 
     var profileName = config.profileName;
     if (!profileName.isBlank()) {

--- a/src/main/java/software/amazon/event/kafkaconnector/auth/EventBridgeAwsCredentialsProviderFactory.java
+++ b/src/main/java/software/amazon/event/kafkaconnector/auth/EventBridgeAwsCredentialsProviderFactory.java
@@ -12,7 +12,6 @@ import org.apache.kafka.common.Configurable;
 import org.slf4j.Logger;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
-import software.amazon.awssdk.profiles.ProfileFile;
 import software.amazon.awssdk.profiles.ProfileFileSupplier;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sts.StsClient;

--- a/src/test/java/software/amazon/event/kafkaconnector/auth/EventBridgeCredentialsProviderFactoryTest.java
+++ b/src/test/java/software/amazon/event/kafkaconnector/auth/EventBridgeCredentialsProviderFactoryTest.java
@@ -67,20 +67,4 @@ public class EventBridgeCredentialsProviderFactoryTest {
     assertThat(provider).isInstanceOf(AwsCredentialsProvider.class);
     assertThat(provider).isExactlyInstanceOf(AwsCredentialProviderImpl.class);
   }
-
-  @Test
-  @Disabled // Todo: Excluded because it is environment specific (Requires no credentials and config
-  // files present to work). Will keep to verify once AWS SDK issue is fixed:
-  // https://github.com/aws/aws-sdk-java-v2/issues/5635
-  public void shouldNotGetSDKClientExceptionWithNull() {
-    var props = new HashMap<>(commonProps);
-    var provider =
-        EventBridgeAwsCredentialsProviderFactory.getAwsCredentialsProvider(
-            new EventBridgeSinkConfig(props));
-    var exception = assertThrows(SdkClientException.class, provider::resolveCredentials);
-
-    assertThat(exception)
-        .hasMessageNotContaining(
-            "Cannot invoke \"java.nio.file.Path.getFileSystem()\" because \"path\" is null");
-  }
 }

--- a/src/test/java/software/amazon/event/kafkaconnector/auth/EventBridgeCredentialsProviderFactoryTest.java
+++ b/src/test/java/software/amazon/event/kafkaconnector/auth/EventBridgeCredentialsProviderFactoryTest.java
@@ -5,15 +5,12 @@
 package software.amazon.event.kafkaconnector.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.HashMap;
 import java.util.Map;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
-import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
 import software.amazon.event.kafkaconnector.AwsCredentialProviderImpl;
 import software.amazon.event.kafkaconnector.EventBridgeSinkConfig;


### PR DESCRIPTION
Final resolution for https://github.com/aws/eventbridge-kafka-connector/issues/396 because underlying issue was fixed in AWS SDK: https://github.com/aws/aws-sdk-java-v2/issues/5635